### PR TITLE
Extend the `Incident.genders` values and add `archived` column

### DIFF
--- a/backend/app/controllers/api/v1/incidents_controller.rb
+++ b/backend/app/controllers/api/v1/incidents_controller.rb
@@ -26,7 +26,8 @@ class Api::V1::IncidentsController < ApplicationController
 
   def incident_params
     params.require(:incident).permit(
-      :longitude, :latitude, :age, :gender, :status, :confirmed, :address, :description
+      :longitude, :latitude, :age, :gender, :status, :confirmed, :address, :description,
+      :archived
     )
   end
 end

--- a/backend/app/models/incident.rb
+++ b/backend/app/models/incident.rb
@@ -16,7 +16,7 @@
 #
 
 class Incident < ApplicationRecord
-  enum gender: %i(male female)
+  enum gender: %i(male female unknown other)
   enum status: %i(suspicious awaiting_result positive recoveried dead)
 
   validates :latitude, :longitude, :status, :gender, :age, presence: true

--- a/backend/app/models/incident.rb
+++ b/backend/app/models/incident.rb
@@ -13,6 +13,7 @@
 #  confirmed   :boolean          not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  archived    :boolean          default(FALSE)
 #
 
 class Incident < ApplicationRecord

--- a/backend/db/migrate/20200509234742_add_archived_to_incidents.rb
+++ b/backend/db/migrate/20200509234742_add_archived_to_incidents.rb
@@ -1,0 +1,5 @@
+class AddArchivedToIncidents < ActiveRecord::Migration[6.0]
+  def change
+    add_column :incidents, :archived, :boolean, default: false
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_07_013832) do
+ActiveRecord::Schema.define(version: 2020_05_09_234742) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 2020_05_07_013832) do
     t.boolean "confirmed", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "archived", default: false
   end
 
 end

--- a/backend/test/fixtures/incidents.yml
+++ b/backend/test/fixtures/incidents.yml
@@ -13,6 +13,7 @@
 #  confirmed   :boolean          not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  archived    :boolean          default(FALSE)
 #
 
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html

--- a/backend/test/models/incident_test.rb
+++ b/backend/test/models/incident_test.rb
@@ -13,6 +13,7 @@
 #  confirmed   :boolean          not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  archived    :boolean          default(FALSE)
 #
 
 require 'test_helper'


### PR DESCRIPTION
## Description

- [x] This PR adds the `unknown` and `other` genders to the `Incident` model. 
- [x] Add the `archived` column to the `incidents` table.
- [x] Allow the `:incident` param in the `Api::V1::IncidentsController`.