### PR TITLE
Return consistent error when creating a new session

### DIFF
--- a/backend/app/controllers/api/v1/sessions_controller.rb
+++ b/backend/app/controllers/api/v1/sessions_controller.rb
@@ -7,10 +7,10 @@ class Api::V1::SessionsController < ApplicationController
     if @user&.authenticate(params[:password])
       render json: session_payload, status: :ok
     else
-      render json: { error: 'You are not logged in.' }, status: :unauthorized
+      render json: { error: 'Invalid username or password' }, status: :unauthorized
     end
-  rescue ActiveRecord::RecordNotFound
-    render json: { errors: "User not found" }, status: :not_found
+  rescue
+    render json: { errors: "Invalid username or password" }, status: :unauthorized
   end
 
   private


### PR DESCRIPTION
## Description

We should return "Invalid username or password" when creating a does not succeed. 

- [x] Return "Invalid username or password" error when the user is not able to sign in. 