### PR TITLE
Add seeds for users

### DIFF
--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -20,7 +20,8 @@ class User < ApplicationRecord
   has_secure_password
   enum status: %i(active pending blocked)
 
-  validates :name, :last_name, :email, :username, :password, :status, presence: true
+  validates :name, :email, :username, :password, :status, presence: true
+  validates :last_name, presence: true, unless: :organization?
   validates :email, uniqueness: true
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
   validates :username, uniqueness: true
@@ -28,10 +29,26 @@ class User < ApplicationRecord
             length: { minimum: 6 },
             if: -> { new_record? || !password.nil? }
 
-  before_create :set_status_to_pending
+  # before_create :set_status_to_pending
 
+  # Pending: Send user confirmation email
   def set_status_to_pending
     self.status = :pending
-    # Pending: Send user confirmation email
+  end
+
+  def admin?
+    admin
+  end
+
+  def validator?
+    validator
+  end
+
+  def organization?
+    organization
+  end
+
+  def regular?
+    !admin? && !validator? && !organization?
   end
 end

--- a/backend/db/migrate/20200511125217_create_users.rb
+++ b/backend/db/migrate/20200511125217_create_users.rb
@@ -2,7 +2,7 @@ class CreateUsers < ActiveRecord::Migration[6.0]
   def change
     create_table :users do |t|
       t.string :name            , null: false
-      t.string :last_name       , null: false
+      t.string :last_name       , null: true
       t.string :email           , null: false
       t.string :username        , null: false
       t.string :password_digest , null: false

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -31,7 +31,7 @@ ActiveRecord::Schema.define(version: 2020_05_11_125217) do
 
   create_table "users", force: :cascade do |t|
     t.string "name", null: false
-    t.string "last_name", null: false
+    t.string "last_name"
     t.string "email", null: false
     t.string "username", null: false
     t.string "password_digest", null: false

--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -1,12 +1,6 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
-
+# Clean up existing records
 Incident.destroy_all
+User.destroy_all
 
 # Random set of real coordinates from Medellin - Antioquia
 coordinates = [
@@ -22,6 +16,7 @@ coordinates = [
   { latitude: 6.180503, longitude: -75.587509 }
 ]
 
+# Incidents
 coordinates.each do |c|
   incident = Incident.create!(
     latitude: c[:latitude],
@@ -34,3 +29,34 @@ coordinates.each do |c|
     gender: Incident.genders.values.sample
   )
 end
+
+# Users
+# Create 5 users: one admin, two validators, one hospital, one city hall and three
+# regular users.
+
+def create_user(params)
+  attributes = params.merge(
+    status: "active",
+    password: "crown-tracker",
+    password_confirmation: "crown-tracker"
+  )
+
+  User.create!(attributes)
+end
+
+# Create `admin` user
+create_user(name: "Marco", last_name: "Polo", email: "marco-polo@crown.com", username: "marco-polo", admin: true)
+# Create `validator` user
+create_user(name: "Carlos", last_name: "Torres", email: "carlos-torres@crown.com", username: "carlos-torres", validator: true)
+# Create `validator` user
+create_user(name: "Andres", last_name: "Lopez", email: "andres-lopez@crown.com", username: "andres-lopez", validator: true)
+# Create `organization` user
+create_user(name: "Hospital Pablo Tobón Uribe", email: "hospital@crown.com", username: "hospital", organization: true)
+# Create `organization` user
+create_user(name: "Alcaldía de Medellín", email: "city-hall@crown.com", username: "city_hall", organization: true)
+# Create `regular` user
+create_user(name: "Pedro", last_name: "Perez", email: "pedro-perez@crown.com", username: "pedro-perez")
+# Create `regular` user
+create_user(name: "Pablo", last_name: "Castro", email: "pablo-castro@crown.com", username: "pablo-castro")
+# Create `regular` user
+create_user(name: "Cristina", last_name: "Palacios", email: "cristina-palacios@crown.com", username: "cristina-palacios")


### PR DESCRIPTION
## Description 

This PR adds the following changes: 

- [x] Remove a database constraint for the `users.last_name` column. It should accept `null` values since organizations are unlikely to have a `last_name`. 

- [x] Update the `User#last_name` presence validation and deactivate user's validation workflow. It should be addressed very soon. 

- [x] Add new seeds for creating users(local environment). It creates `admin`, `validator`, `organization` and `regular` users. Check the 'app/db/seeds.rb' file for more info.

## Additional

Please run `rails db:drop`,` rails db:create` and rails` db:seed `for adding the database changes and the new seeds. Maybe doing `rails db:reset` runs all the three commands. 
